### PR TITLE
work around windows exe wrapper

### DIFF
--- a/util/decompile.py
+++ b/util/decompile.py
@@ -111,7 +111,7 @@ def stdout_decompile(cmd: str, args: List[str], dest_path: str) -> Tuple[bool, C
     :return: tuple of (True iff the command succeeded completely, the CompletedProcess object
     """
     success, result = exec_cli(cmd, args)
-    if len(result.stdout) > 0:
+    if result and result.stdout and len(result.stdout) > 0:
         try:
             with open(dest_path, "w", encoding="utf-8") as file:
                 file.write(result.stdout)
@@ -148,7 +148,7 @@ def decompile_worker(src_file: str, dest_path: str):
         nonlocal _all_errors
         # TODO: more accurately count "real" lines of code (e.g. exclude byte code and infinitely repeating statements)
         if os.path.isfile(dest_files[which]):
-            with open(dest_files[which], "rbU") as fi:
+            with open(dest_files[which], "rb") as fi:
                 dest_lines[which] = sum(1 for _ in fi)
         if result and not success:
             if result.stderr:


### PR DESCRIPTION
The Windows .exe Wrapper

In your `exec_cli` function, you are setting a timeout:
`kwargs.setdefault("timeout", decompiler_timeout)`

When Python hits this timeout during `subprocess.run`, it attempts to kill the target executable. However, on Windows, packages installed via pip (like decompyle3 or uncompyle6) place a small .exe wrapper in the Windows Scripts folder.

This wrapper's only job is to instantly spawn a hidden, secondary python.exe process to run the actual decompiler script.
When subprocess.run times out, Windows only kills the wrapper. The hidden python.exe process becomes an orphan, continues running in the background indefinitely, and keeps your dest_path file locked. When your worker hits the finally block and tries to `os.remove(file)`, it aborts with `WinError 32`.

The best way to fix this is to stop calling the .exe wrappers and instead call Python directly, telling it to run the module. When subprocess.run times out, it will kill the actual python.exe process, immediately freeing the file handle.

I'm not sure if this will still work with other OS environments, but this fixes it for me on Windows 11.

The U (Universal Newlines) flag in binary mode ("rbU") is deprecated and heavily frowned upon in Python 3. While Python 3.7 might just throw a `DeprecationWarning`, modern Python versions will outright crash with a `ValueError`. It's safer to just use `"rb"` or use text mode `("r")`.

Some other minor cleanup:

If `exec_cli` encounters a general exception (like a missing executable), it returns `False, None`. This makes result equal to `None`. Attempting to access `result.stdout` will raise an `AttributeError`. Because you have a bare except Exception: block immediately beneath this, it will swallow the `AttributeError`, masking the real reason your command failed.
Fix: Change it to check if result exists first

If `capture_output=True` is bypassed for any reason, `result.stderr` might equal `None`. If you cast `str(None)`, Python evaluates it as the string `"None"`. Because `"None"` is not an empty string, not `"None"` evaluates to `False`. This will cause successful decompilations to be flagged as failures.
Fix: Drop the `str()` cast. Rely on Python's built-in truthiness.

Feel free to use if you want or reject.